### PR TITLE
Here's how I'd describe the changes I've made:

### DIFF
--- a/bot/cogs/download.py
+++ b/bot/cogs/download.py
@@ -678,6 +678,35 @@ class Download(commands.Cog):
         })
         await ctx.send(f"Downloading {url} as mix...")
 
+    @commands.command(name="help_download")
+    async def help_download_command(self, ctx: commands.Context):
+        """Displays help information for all download commands."""
+        embed = discord.Embed(
+            title="Download Commands",
+            description="Here's a list of available download commands:",
+            color=discord.Color.blue()  # You can choose any color
+        )
+
+        for command in self.get_commands():
+            if command.name == "help_download":  # Don't include the help command itself
+                continue
+
+            name = command.name
+            # params = [param for param in command.params if param not in ("self", "ctx")] # Not strictly needed if using signature
+
+            # Try to generate a more user-friendly signature
+            if command.signature:
+                usage = f"`{ctx.prefix}{name} {command.signature}`"
+            else:
+                usage = f"`{ctx.prefix}{name}`" # Fallback if signature is empty
+
+            # Use the command's short doc or the full docstring
+            description = command.short_doc or command.help or "No description available."
+
+            embed.add_field(name=name.capitalize(), value=f"{description}\n**Usage:** {usage}", inline=False)
+
+        await ctx.send(embed=embed)
+
 
 async def setup(bot):
     await bot.add_cog(Download(bot))

--- a/bot/cogs/league.py
+++ b/bot/cogs/league.py
@@ -235,6 +235,34 @@ class League(commands.Cog):
         if isinstance(exc, discord.ext.commands.errors.CommandOnCooldown):
             await ctx.send("Command on cooldown. Please wait " + str(exc.retry_after) + " seconds.")
             
+    @commands.command(name="help_league")
+    async def help_league_command(self, ctx: commands.Context):
+        """Displays help information for all league commands."""
+        embed = discord.Embed(
+            title="League Commands",
+            description="Here's a list of available league commands:",
+            color=discord.Color.blue()  # You can choose any color
+        )
+
+        for command in self.get_commands():
+            if command.name == "help_league":  # Don't include the help command itself
+                continue
+
+            name = command.name
+            # params = [param for param in command.params if param not in ("self", "ctx")] # Not strictly needed if using signature
+
+            # Try to generate a more user-friendly signature
+            if command.signature:
+                usage = f"`{ctx.prefix}{name} {command.signature}`"
+            else:
+                usage = f"`{ctx.prefix}{name}`" # Fallback if signature is empty
+
+            # Use the command's short doc or the full docstring
+            description = command.short_doc or command.help or "No description available."
+
+            embed.add_field(name=name.capitalize(), value=f"{description}\n**Usage:** {usage}", inline=False)
+
+        await ctx.send(embed=embed)
             
 async def setup(bot):
     await bot.add_cog(League(bot))

--- a/bot/cogs/music.py
+++ b/bot/cogs/music.py
@@ -504,6 +504,35 @@ class Music(commands.Cog):
         elif isinstance(exc, IncorrectArgumentType):
             await ctx.send("Incorrect argument supplied to search.")
 
+    @commands.command(name="help_music")
+    async def help_music_command(self, ctx: commands.Context):
+        """Displays help information for all music commands."""
+        embed = discord.Embed(
+            title="Music Commands",
+            description="Here's a list of available music commands:",
+            color=discord.Color.blue()  # You can choose any color
+        )
+
+        for command in self.get_commands():
+            if command.name == "help_music":  # Don't include the help command itself
+                continue
+
+            name = command.name
+            params = [param for param in command.params if param not in ("self", "ctx")]
+
+            # Try to generate a more user-friendly signature
+            if command.signature:
+                usage = f"`{ctx.prefix}{name} {command.signature}`"
+            else:
+                usage = f"`{ctx.prefix}{name}`" # Fallback if signature is empty
+
+            # Use the command's short doc or the full docstring
+            description = command.short_doc or command.help or "No description available."
+
+            embed.add_field(name=name.capitalize(), value=f"{description}\n**Usage:** {usage}", inline=False)
+
+        await ctx.send(embed=embed)
+
 
 async def setup(bot):
     await bot.add_cog(Music(bot))

--- a/bot/cogs/torrent.py
+++ b/bot/cogs/torrent.py
@@ -29,6 +29,35 @@ class Torrent(commands.Cog):
         """Torrents a video from selected platform."""
         await ctx.send(f"{platform}, {search_term}")
 
+    @commands.command(name="help_torrent")
+    async def help_torrent_command(self, ctx: commands.Context):
+        """Displays help information for all torrent commands."""
+        embed = discord.Embed(
+            title="Torrent Commands",
+            description="Here's a list of available torrent commands:",
+            color=discord.Color.blue()  # You can choose any color
+        )
+
+        for command in self.get_commands():
+            if command.name == "help_torrent":  # Don't include the help command itself
+                continue
+
+            name = command.name
+            # params = [param for param in command.params if param not in ("self", "ctx")] # Not strictly needed if using signature
+
+            # Try to generate a more user-friendly signature
+            if command.signature:
+                usage = f"`{ctx.prefix}{name} {command.signature}`"
+            else:
+                usage = f"`{ctx.prefix}{name}`" # Fallback if signature is empty
+
+            # Use the command's short doc or the full docstring
+            description = command.short_doc or command.help or "No description available."
+
+            embed.add_field(name=name.capitalize(), value=f"{description}\n**Usage:** {usage}", inline=False)
+
+        await ctx.send(embed=embed)
+
 
 async def setup(bot):
     await bot.add_cog(Torrent(bot))


### PR DESCRIPTION
I've added a new help command to each cog (`Music`, `Download`, `League`, `Torrent`). When you use this command, you'll see an embed with a list of all commands in that cog, including their names, arguments, and descriptions with examples.

Here's a summary of what I did:
- I added a `help_music` command to the `Music` cog.
- I added a `help_download` command to the `Download` cog.
- I added a `help_league` command to the `League` cog.
- I added a `help_torrent` command to the `Torrent` cog.

Each of these new help commands:
- Is named to match its cog (for example, `help_music`).
- Doesn't require any arguments from you.
- Creates a `discord.Embed` with a title specific to its cog.
- Goes through all the commands within its own cog.
- For each command it finds, it shows you its name, how to use it (the parameters), and what it does.
- Finally, it sends this helpful embed to the channel where you used the command.